### PR TITLE
Initial attempt to make spool size configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,4 @@ default["logstash-forwarder"]["files"]                      = { "syslog" => [ '/
 default["logstash-forwarder"]["logstash_role"]              = "logstash"
 default["logstash-forwarder"]["logstash_fqdn"]              = ""
 default["logstash-forwarder"]["config_file"]                = "#{node["logstash-forwarder"]["dir"]}/logstash-forwarder.conf"
+default["logstash-forwarder"]["spool_size"]                 = "1024"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,7 +85,8 @@ when "debian"
       :user             => node["logstash-forwarder"]["user"],
       :group            => node["logstash-forwarder"]["group"],
       :log_dir          => node["logstash-forwarder"]["log_dir"],
-      :config_file      => node["logstash-forwarder"]["config_file"]
+      :config_file      => node["logstash-forwarder"]["config_file"],
+      :spool_size       => node["logstash-forwarder"]["spool_size"]
     )
     notifies :restart, "service[logstash-forwarder]"
   end

--- a/templates/default/logstash-forwarder.conf.erb
+++ b/templates/default/logstash-forwarder.conf.erb
@@ -10,7 +10,7 @@ respawn limit 5 30
 chdir <%= @dir %>
 
 script
-  exec sudo -u <%= @user %> <%= @dir %>/bin/logstash-forwarder.sh -config <%= @config_file %> >> <%= @log_dir %>/logstash-forwarder.log 2>&1
+exec sudo -u <%= @user %> <%= @dir %>/bin/logstash-forwarder.sh -config <%= @config_file %> -spool-size <%= @spool_size %> >> <%= @log_dir %>/logstash-forwarder.log 2>&1
 end script
 
 emits logstash-forwarder-running


### PR DESCRIPTION
Allow the recipe to configure the logstash-forwarder's spool size.  The
default is 1024, same as the forwarder binary's.
