### PR TITLE
Explode if nil log filepaths are passed to the config generator.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,7 +11,9 @@ end
 host_hash = host_hash[0...-1]
 
 file_list = "  \"files\": ["
-node["logstash-forwarder"]["files"].each do |type, files| 
+node["logstash-forwarder"]["files"].each do |type, files|
+  raise "Invalid path(s) configured for type #{type}, this is possibly due to attribute loading precedence in your chef config." if files.any? &:nil?
+
   if !files.empty?
     file_list = file_list + "\n    {\n"
     file_list = file_list + "      \"paths\": #{files},\n"


### PR DESCRIPTION
Tested against our previous config and it successfully exploded:

```
==> default: ================================================================================
==> default:   
==> default: Recipe Compile Error in /opt/kitchen/site-cookbooks/outreach/recipes/logstash-forwarder.rb
==> default:   
==> default: ================================================================================
==> default:   
==> default: 
==> default: 
==> default:   
==> default: RuntimeError
==> default:   
==> default: ------------
==> default:   
==> default: Invalid path(s) configured for type outreach-platform, this is possibly due to attribute loading precedence in your chef config.
==> default:   
```
