### PR TITLE
Add support for host-specific extra fields

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default["logstash-forwarder"]["ssl_certificate_path"]       = ""
 default["logstash-forwarder"]["ssl_key_path"]               = ""
 default["logstash-forwarder"]["ssl_ca_certificate_path"]    = ""
 default["logstash-forwarder"]["files"]                      = { "syslog" => [ '/var/log/syslog' ]}
+default["logstash-forwarder"]["extra_fields"]               = {}
 default["logstash-forwarder"]["logstash_role"]              = "logstash"
 default["logstash-forwarder"]["logstash_fqdn"]              = ""
 default["logstash-forwarder"]["config_file"]                = "#{node["logstash-forwarder"]["dir"]}/logstash-forwarder.conf"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,13 @@ node["logstash-forwarder"]["files"].each do |type, files|
   if !files.empty?
     file_list = file_list + "\n    {\n"
     file_list = file_list + "      \"paths\": #{files},\n"
-    file_list = file_list + "      \"fields\": { \"type\": \"#{type}\" }\n"
+
+    fields = ["\"type\": \"#{type}\""]
+    node["logstash-forwarder"]["extra_fields"].each do |field, value|
+      fields.push("\"#{field}\": \"#{value}\"")
+    end
+
+    file_list = file_list + "      \"fields\": { #{fields.join ", "} }\n"
     file_list = file_list + "    },"
   end
 end


### PR DESCRIPTION
Adds extra fields to every log forwarded from this logstash instance.
These fields are specified as a Chef attribute containing a hash.
Defaults to the empty hash, which is 100% backwards-compatible with the
old behavior.
